### PR TITLE
Include full address in application-updated event

### DIFF
--- a/domains/POAS/events/application-updated/examples/example.json
+++ b/domains/POAS/events/application-updated/examples/example.json
@@ -6,7 +6,14 @@
     "firstNames": "Jack",
     "lastName": "Rubik",
     "dob": "1938-03-18",
-    "postcode": "N184EQ"
+    "address": {
+      "line1": "Flat 312",
+      "line2": "1 Scotland Street",
+      "line3": "Old Town",
+      "town": "Edinburgh",
+      "postcode": "N184EQ",
+      "country": "GB"
+    }
   },
   "previousApplicationUid": "M-4567-1234-0001"
 }

--- a/domains/POAS/events/application-updated/schema.json
+++ b/domains/POAS/events/application-updated/schema.json
@@ -64,7 +64,7 @@
           "required": ["line1", "town", "country"]
         }
       },
-      "required": ["firstNames", "lastName", "dob"]
+      "required": ["firstNames", "lastName", "dob", "address"]
     }
   },
   "required": ["uid", "type", "createdAt", "donor"]

--- a/domains/POAS/events/application-updated/schema.json
+++ b/domains/POAS/events/application-updated/schema.json
@@ -35,13 +35,36 @@
           "description": "The date of birth of the donor",
           "format": "date"
         },
-        "postcode": {
-          "type": "string",
-          "description": "The postcode of the donor's address",
-          "pattern": "[A-Z0-9 ]{1,9}"
+        "address": {
+          "type": "object",
+          "description": "The donor's address",
+          "properties": {
+            "line1": {
+              "type": "string"
+            },
+            "line2": {
+              "type": "string"
+            },
+            "line3": {
+              "type": "string"
+            },
+            "town": {
+              "type": "string"
+            },
+            "postcode": {
+              "type": "string",
+              "pattern": "[A-Z0-9 ]{1,9}"
+            },
+            "country": {
+              "type": "string",
+              "description": "2-digit ISO 3166-1 country code per FCDO definitions: https://www.gov.uk/government/publications/geographical-names-and-information",
+              "pattern": "[A-Z]{2}"
+            }
+          },
+          "required": ["line1", "town", "country"]
         }
       },
-      "required": ["firstNames", "lastName", "dob", "postcode"]
+      "required": ["firstNames", "lastName", "dob"]
     }
   },
   "required": ["uid", "type", "createdAt", "donor"]


### PR DESCRIPTION
Rather than just including the postcode, include the full address of the donor.

This will allow case workers to send correspondence to the donor, such as requests for reduced fee evidence.

Technically a major change since it moves the `postcode` field, however Sirius will expand/contract to support both structures during the transition.

For VEGA-2082 #minor