### PR TITLE
VEGA-2287 Allow new LPA types in events #minor

### DIFF
--- a/domains/POAS/events/application-updated/schema.json
+++ b/domains/POAS/events/application-updated/schema.json
@@ -12,7 +12,7 @@
     "type": {
       "type": "string",
       "description": "The type of LPA being applied for",
-      "enum": ["hw", "pfa", "pw", "pa"]
+      "enum": ["hw", "pfa", "personal-welfare", "property-and-affairs"]
     },
     "createdAt": {
       "type": "string",

--- a/domains/POAS/events/application-updated/schema.json
+++ b/domains/POAS/events/application-updated/schema.json
@@ -12,7 +12,7 @@
     "type": {
       "type": "string",
       "description": "The type of LPA being applied for",
-      "enum": ["hw", "pfa"]
+      "enum": ["hw", "pfa", "pw", "pa"]
     },
     "createdAt": {
       "type": "string",

--- a/domains/POAS/events/uid-requested/schema.json
+++ b/domains/POAS/events/uid-requested/schema.json
@@ -17,7 +17,7 @@
     "type": {
       "type": "string",
       "description": "The type of LPA being created",
-      "enum": ["pfa", "hw", "pw", "pa"]
+      "enum": ["pfa", "hw", "personal-welfare", "property-and-affairs"]
     },
     "donor": {
       "type": "object",

--- a/domains/POAS/events/uid-requested/schema.json
+++ b/domains/POAS/events/uid-requested/schema.json
@@ -17,7 +17,7 @@
     "type": {
       "type": "string",
       "description": "The type of LPA being created",
-      "enum": ["pfa", "hw"]
+      "enum": ["pfa", "hw", "pw", "pa"]
     },
     "donor": {
       "type": "object",


### PR DESCRIPTION
Support "personal-welfare" and "property-and-affairs" LPA types, as used for digital LPAs.