### PR TITLE
MRLPAB-1558: Add notification-sent event

### DIFF
--- a/domains/POAS/events/notification-sent/examples/example.json
+++ b/domains/POAS/events/notification-sent/examples/example.json
@@ -1,5 +1,4 @@
 {
   "uid": "M-1234-5678-9012",
-  "deliveryMethod": "Email",
-  "subject": "CertificateProviderInvite"
+  "notificationId": "740e5834-3a29-46b4-9a6f-16142fde533a"
 }

--- a/domains/POAS/events/notification-sent/examples/example.json
+++ b/domains/POAS/events/notification-sent/examples/example.json
@@ -1,0 +1,5 @@
+{
+  "uid": "M-1234-5678-9012",
+  "deliveryMethod": "Email",
+  "subject": "CertificateProviderInvite"
+}

--- a/domains/POAS/events/notification-sent/index.md
+++ b/domains/POAS/events/notification-sent/index.md
@@ -1,0 +1,22 @@
+---
+name: notification-sent
+version: 0.0.1
+summary: |
+  A notification has been sent by MRLPA to an actor on a LPA
+producers:
+    - opg.poas.makeregister
+consumers:
+    - opg.poas.sirius
+owners:
+    - mrlpa
+---
+
+## Details
+
+MRLPA sends SMS and email notifications to LPA actors via GOV UK Notify. OPG caseworkers need to know when these notifications have been sent to support queries made to the contact centre and, in some cases, to trigger other actions within Sirius.
+
+<NodeGraph title="Consumer / Producer Diagram" />
+
+<EventExamples />
+
+<Schema />

--- a/domains/POAS/events/notification-sent/schema.json
+++ b/domains/POAS/events/notification-sent/schema.json
@@ -16,8 +16,7 @@
     },
     "subject": {
       "type": "string",
-      "description": "What the notification was about",
-      "enum": ["CertificateProviderInvite"]
+      "description": "What the notification was about"
     }
   },
   "required": ["uid", "deliveryMethod", "subject"]

--- a/domains/POAS/events/notification-sent/schema.json
+++ b/domains/POAS/events/notification-sent/schema.json
@@ -9,15 +9,11 @@
       "description": "The UID of the LPA",
       "pattern": "M(-[A-Z0-9]{4}){3}"
     },
-    "deliveryMethod": {
+    "notificationId": {
       "type": "string",
-      "description": "How the notification was sent",
-      "enum": ["Email", "SMS"]
-    },
-    "subject": {
-      "type": "string",
-      "description": "What the notification was about"
+      "description": "The GOV UK Notify id of the notification sent",
+      "pattern": "([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})"
     }
   },
-  "required": ["uid", "deliveryMethod", "subject"]
+  "required": ["uid", "notificationId"]
 }

--- a/domains/POAS/events/notification-sent/schema.json
+++ b/domains/POAS/events/notification-sent/schema.json
@@ -1,0 +1,24 @@
+{
+  "$id": "https://opg.service.justice.gov.uk/opg.poas.sirius/notification-sent.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "opg.poas.makeregister/notification-sent",
+  "type": "object",
+  "properties": {
+    "uid": {
+      "type": "string",
+      "description": "The UID of the LPA",
+      "pattern": "M(-[A-Z0-9]{4}){3}"
+    },
+    "deliveryMethod": {
+      "type": "string",
+      "description": "How the notification was sent",
+      "enum": ["Email"]
+    },
+    "subject": {
+      "type": "string",
+      "description": "What the notification was about",
+      "enum": ["CertificateProviderInvite"]
+    }
+  },
+  "required": ["uid", "deliveryMethod", "subject"]
+}

--- a/domains/POAS/events/notification-sent/schema.json
+++ b/domains/POAS/events/notification-sent/schema.json
@@ -12,7 +12,7 @@
     "deliveryMethod": {
       "type": "string",
       "description": "How the notification was sent",
-      "enum": ["Email"]
+      "enum": ["Email", "SMS"]
     },
     "subject": {
       "type": "string",


### PR DESCRIPTION
~~This ticket only deals with an email notification but we have a few tickets in this epic around updating Sirius on SMSs sent so I've included both delivery methods as enums.~~

Now relying on notification ID so Sirius can get all the required details from Notify directly.