### PR TITLE
VEGA-2523 : Move Payment Received event out of proposed state

### DIFF
--- a/domains/POAS/events/payment-received/index.md
+++ b/domains/POAS/events/payment-received/index.md
@@ -6,7 +6,7 @@ summary: |
 producers:
   - opg.poas.makeregister
 consumers:
-  - opg.poas.sirius-proposed
+  - opg.poas.sirius
 owners:
   - vega
   - mrlpa


### PR DESCRIPTION
This change covers [VEGA-2523](https://opgtransform.atlassian.net/browse/VEGA-2523)

Sirius has done the implementation to handle the 'payment-received' event that comes from Make and Register. So the event is now being moved out of the proposed state.

[VEGA-2523]: https://opgtransform.atlassian.net/browse/VEGA-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ