### PR TITLE
VEGA-2594 : Move events out of proposed state

### DIFF
--- a/domains/POAS/events/attorney-started/index.md
+++ b/domains/POAS/events/attorney-started/index.md
@@ -6,7 +6,7 @@ summary: |
 producers:
   - opg.poas.makeregister
 consumers:
-  - opg.poas.sirius-proposed
+  - opg.poas.sirius
 owners:
   - vega
   - mrlpa

--- a/domains/POAS/events/certificate-provider-started/index.md
+++ b/domains/POAS/events/certificate-provider-started/index.md
@@ -6,7 +6,7 @@ summary: |
 producers:
   - opg.poas.makeregister
 consumers:
-  - opg.poas.sirius-proposed
+  - opg.poas.sirius
 owners:
   - vega
   - mrlpa


### PR DESCRIPTION
This change covers [VEGA-2594](https://opgtransform.atlassian.net/browse/VEGA-2594) and [VEGA-2391](https://opgtransform.atlassian.net/browse/VEGA-2391)

Sirius has done the implementation to handle the 'certificate-provider-started' event and 'attorney-started' event that comes from Make and Register. So the event is now being moved out of the proposed state.

[VEGA-2594]: https://opgtransform.atlassian.net/browse/VEGA-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VEGA-2391]: https://opgtransform.atlassian.net/browse/VEGA-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ