### PR TITLE
Remove previousApplicationUid

### DIFF
--- a/domains/POAS/events/application-updated/examples/example.json
+++ b/domains/POAS/events/application-updated/examples/example.json
@@ -14,6 +14,5 @@
       "postcode": "N184EQ",
       "country": "GB"
     }
-  },
-  "previousApplicationUid": "M-4567-1234-0001"
+  }
 }


### PR DESCRIPTION
It isn't part of the schema, isn't set by MRLPA, and isn't used by Sirius.

#patch