### PR TITLE
Update format of actorUID fields

### DIFF
--- a/domains/POAS/events/attorney-started/examples/example.json
+++ b/domains/POAS/events/attorney-started/examples/example.json
@@ -1,4 +1,4 @@
 {
   "uid": "M-1234-5678-9012",
-  "actorUID": "urn:opg:poas:makeregister:users:740e5834-3a29-46b4-9a6f-16142fde533a"
+  "actorUID": "740e5834-3a29-46b4-9a6f-16142fde533a"
 }

--- a/domains/POAS/events/attorney-started/schema.json
+++ b/domains/POAS/events/attorney-started/schema.json
@@ -12,7 +12,7 @@
     "actorUID": {
       "type": "string",
       "description": "The UID of the attorney",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
+      "pattern": "^([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
     }
   },
   "required": ["uid", "actorUID"]

--- a/domains/POAS/events/identity-check-mismatched/examples/example.json
+++ b/domains/POAS/events/identity-check-mismatched/examples/example.json
@@ -1,6 +1,6 @@
 {
   "uid": "M-0000-1111-2222",
-  "actorUID": "urn:opg:poas:makeregister:users:740e5834-3a29-46b4-9a6f-16142fde533a",
+  "actorUID": "740e5834-3a29-46b4-9a6f-16142fde533a",
   "provided": {
     "firstNames": "John",
     "lastName": "Smith",

--- a/domains/POAS/events/identity-check-mismatched/schema.json
+++ b/domains/POAS/events/identity-check-mismatched/schema.json
@@ -12,7 +12,7 @@
     "actorUID": {
       "type": "string",
       "description": "The UID of the actor the identity check relates to",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
+      "pattern": "^([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
     },
     "provided": {
       "description": "The data as provided on the LPA",

--- a/domains/POAS/events/lpa-updated/examples/other.json
+++ b/domains/POAS/events/lpa-updated/examples/other.json
@@ -1,5 +1,4 @@
 {
   "uid": "M-1234-5678-9012",
-  "actorUID": "urn:opg:poas:makeregister:users:740e5834-3a29-46b4-9a6f-16142fde533a",
   "changeType": "CERTIFICATE_PROVIDER_SIGN"
 }

--- a/domains/POAS/events/lpa-updated/schema.json
+++ b/domains/POAS/events/lpa-updated/schema.json
@@ -9,11 +9,6 @@
       "description": "The UID of the LPA",
       "pattern": "^M(-[A-Z0-9]{4}){3}$"
     },
-    "actorUID": {
-      "type": "string",
-      "description": "The UID of the actor the change relates to",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
-    },
     "changeType": {
       "type": "string",
       "description": "The type of change to the LPA",
@@ -31,7 +26,7 @@
         "properties": {
           "changeType": { "const": "CERTIFICATE_PROVIDER_SIGN" }
         },
-        "required": ["uid", "actorUID", "changeType"]
+        "required": ["uid", "changeType"]
       }
     },
     {
@@ -44,7 +39,7 @@
         "properties": {
           "changeType": { "const": "ATTORNEY_SIGN" }
         },
-        "required": ["uid", "actorUID", "changeType"]
+        "required": ["uid", "changeType"]
       }
     },
     {
@@ -57,7 +52,7 @@
         "properties": {
           "changeType": { "const": "TRUST_CORPORATION_SIGN" }
         },
-        "required": ["uid", "actorUID", "changeType"]
+        "required": ["uid", "changeType"]
       }
     },
     {

--- a/domains/POAS/events/paper-form-requested/examples/example.json
+++ b/domains/POAS/events/paper-form-requested/examples/example.json
@@ -1,6 +1,6 @@
 {
   "uid": "M-1234-5678-9012",
   "actorType": "attorney",
-  "actorUID": "urn:opg:poas:makeregister:users:740e5834-3a29-46b4-9a6f-16142fde533a",
+  "actorUID": "740e5834-3a29-46b4-9a6f-16142fde533a",
   "accessCode": "abcdef123456"
 }

--- a/domains/POAS/events/paper-form-requested/schema.json
+++ b/domains/POAS/events/paper-form-requested/schema.json
@@ -17,7 +17,7 @@
     "actorUID": {
       "type": "string",
       "description": "The UID of the actor that needs a paper form",
-      "pattern": "^urn:opg:poas:makeregister:users:([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
+      "pattern": "^([a-z0-9]{8}-)([a-z0-9]{4}-){3}([a-z0-9]{12})$"
     },
     "accessCode": {
       "type": "string",


### PR DESCRIPTION
Remove URN prefix so it's just the UUID stored in the LPA Store.

And remove the `actorUID` field from `lpa-updated` since it's not populated or used by any of our services.

For CTC-192 #minor