### PR TITLE
Add new outcomes to `identity-check-resolved`

### DIFF
--- a/domains/POAS/events/identity-check-resolved/schema.json
+++ b/domains/POAS/events/identity-check-resolved/schema.json
@@ -28,7 +28,7 @@
     },
     "outcome": {
       "type": "string",
-      "enum": ["success", "exit"]
+      "enum": ["success", "failure", "court-of-protection", "exit"]
     }
   }
 }


### PR DESCRIPTION
The resolution could also be a complete failure, or the donor opting to take their case to the Court of Protection.