### PR TITLE
Refactor identity check event

### DIFF
--- a/domains/POAS/events/identity-check-resolved/index.md
+++ b/domains/POAS/events/identity-check-resolved/index.md
@@ -11,6 +11,8 @@ owners:
   - vega
 ---
 
+<Admonition type="alert">This event has been deprecated. Use <a href="../identity-check-updated/">identity-check-updated</a> instead</Admonition>
+
 ## Context
 
 An offline identity check has been resolved, whether successful, a failure or an exit.

--- a/domains/POAS/events/identity-check-updated/examples/cop_started.json
+++ b/domains/POAS/events/identity-check-updated/examples/cop_started.json
@@ -1,0 +1,6 @@
+{
+  "time": "2024-05-19T15:06:29Z",
+  "lpaUids": ["M-14HD-3J9F-FJ9K"],
+  "actorType": "donor",
+  "state": "COP_STARTED"
+}

--- a/domains/POAS/events/identity-check-updated/examples/counter_service_started.json
+++ b/domains/POAS/events/identity-check-updated/examples/counter_service_started.json
@@ -1,0 +1,6 @@
+{
+  "time": "2024-05-19T15:06:29Z",
+  "lpaUids": ["M-14HD-3J9F-FJ9K"],
+  "actorType": "donor",
+  "state": "COUNTER_SERVICE_STARTED"
+}

--- a/domains/POAS/events/identity-check-updated/examples/exit.json
+++ b/domains/POAS/events/identity-check-updated/examples/exit.json
@@ -1,0 +1,6 @@
+{
+  "time": "2024-05-19T15:06:29Z",
+  "lpaUids": ["M-14HD-3J9F-FJ9K"],
+  "actorType": "certificateProvider",
+  "state": "EXIT"
+}

--- a/domains/POAS/events/identity-check-updated/examples/failure.json
+++ b/domains/POAS/events/identity-check-updated/examples/failure.json
@@ -1,0 +1,6 @@
+{
+  "time": "2024-05-19T15:06:29Z",
+  "lpaUids": ["M-14HD-3J9F-FJ9K"],
+  "actorType": "donor",
+  "state": "FAILURE"
+}

--- a/domains/POAS/events/identity-check-updated/examples/success.json
+++ b/domains/POAS/events/identity-check-updated/examples/success.json
@@ -1,0 +1,7 @@
+{
+  "time": "2024-05-19T15:06:29Z",
+  "lpaUids": ["M-14HD-3J9F-FJ9K"],
+  "actorType": "donor",
+  "state": "SUCCESS",
+  "reference": "opg:62cd0995-3d58-40a1-8ed5-9cdb557136af"
+}

--- a/domains/POAS/events/identity-check-updated/examples/vouch_started.json
+++ b/domains/POAS/events/identity-check-updated/examples/vouch_started.json
@@ -1,0 +1,8 @@
+{
+  "time": "2024-05-19T15:06:29Z",
+  "lpaUids": ["M-14HD-3J9F-FJ9K"],
+  "actorType": "donor",
+  "state": "VOUCH_STARTED",
+  "voucherName": "Glennis Edgin",
+  "voucherAddress": ["3 Chestnut Close", "Cleveland", "Dorset", "GT87 1CH"]
+}

--- a/domains/POAS/events/identity-check-updated/index.md
+++ b/domains/POAS/events/identity-check-updated/index.md
@@ -1,0 +1,47 @@
+---
+name: identity-check-updated
+version: 0.0.1
+summary: |
+  An offline identity check has been updated
+producers:
+  - opg.poas.identity-check
+consumers:
+  - opg.poas.sirius
+owners:
+  - vega
+---
+
+## Context
+
+An offline identity check can be a distributed, asynchronous process. In order for OPG to track the progress of an identity check, Sirius needs to be updated when key events occur.
+
+In a happy path journey, an identity check may immediately go to `SUCCESS`. But it may also go through several steps to get there, as shown in the following example:
+
+<Mermaid title="Example complex identity check status journey" charts={[`
+flowchart LR
+  X(Start)-->EXIT
+  EXIT-->COUNTER_SERVICE_STARTED
+  COUNTER_SERVICE_STARTED-->FAILURE
+  FAILURE-->VOUCH_STARTED
+  VOUCH_STARTED-->SUCCESS
+`]} />
+
+## Trigger
+
+This event is triggered at the end of some sort of process in the identity check process. For example, a phone call from an actor might result in a `SUCCESS` state, or `COP_STARTED` if they need to go to the Court of Protection. A notification from our counter service provider that they've reviewed the actor's ID also might result in a `SUCCESS`, or a `FAILURE` if the ID was insufficient.
+
+The important thing is that **every journey in the Paper ID process should provide some sort of update** when it concludes. It is then up to Sirius to decide what happens.
+
+## Effect
+
+In all cases, the relevant progress indicator in Sirius will be updated to reflect the state of the ID check, and a note will be added to the timeline.
+
+If the state is **`SUCCESS`**, the identity check details will be added to the LPA Store record. (If the LPA has not been submitted, the information is held in Sirius until it is.)
+
+If the state is **`VOUCH_STARTED`**, Sirius will send a letter to the voucher once the LPA is submitted. (If the LPA has been submitted, the letter will be sent immediately.)
+
+<NodeGraph title="Consumer / Producer Diagram" />
+
+<EventExamples />
+
+<Schema />

--- a/domains/POAS/events/identity-check-updated/schema.json
+++ b/domains/POAS/events/identity-check-updated/schema.json
@@ -1,0 +1,78 @@
+{
+  "$id": "https://opg.service.justice.gov.uk/opg.poas.identity-check/identity-check-updated.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "opg.poas.identity-check/identity-check-updated",
+  "type": "object",
+  "required": ["time", "lpaUids", "actorType", "state"],
+  "properties": {
+    "time": {
+      "type": "string",
+      "description": "When the update occurred",
+      "format": "date-time"
+    },
+    "lpaUids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "The UIDs of the LPAs associated with the identity check",
+        "pattern": "^M(-[A-Z0-9]{4}){3}$"
+      }
+    },
+    "actorType": {
+      "type": "string",
+      "enum": ["donor", "certificateProvider"],
+      "description": "The type of actor associated with the identity check"
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "COP_STARTED",
+        "COUNTER_SERVICE_STARTED",
+        "EXIT",
+        "FAILURE",
+        "SUCCESS",
+        "VOUCH_STARTED"
+      ]
+    },
+    "reference": {
+      "type": "string",
+      "description": "The back-reference for a successful identity check"
+    },
+    "voucherName": {
+      "type": "string",
+      "description": "The name of the voucher that the donor nominated"
+    },
+    "voucherAddress": {
+      "type": "array",
+      "description": "The mailing address of the voucher that the donor nominated",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["state"],
+        "properties": {
+          "state": { "const": "SUCCESS" }
+        }
+      },
+      "then": {
+        "required": ["reference"]
+      }
+    },
+    {
+      "if": {
+        "required": ["state"],
+        "properties": {
+          "state": { "const": "VOUCH_STARTED" }
+        }
+      },
+      "then": {
+        "required": ["voucherName", "voucherAddress"]
+      }
+    }
+  ]
+}

--- a/test/validate-examples.mjs
+++ b/test/validate-examples.mjs
@@ -12,14 +12,13 @@ const errors = [];
 const __filename = fileURLToPath(import.meta.url);
 
 const schemas = await glob(
-    path.join(path.dirname(__filename), "/../domains/**/schema.json")
-)
+  path.join(path.dirname(__filename), "/../domains/**/schema.json")
+);
 
 for (const schemaPath of schemas) {
-  const examples = await glob(path.join(
-      path.dirname(schemaPath),
-      "**/examples/*.json"
-  ));
+  const examples = await glob(
+    path.join(path.dirname(schemaPath), "**/examples/*.json")
+  );
 
   const eventName = path.basename(path.dirname(schemaPath));
 
@@ -34,16 +33,17 @@ for (const schemaPath of schemas) {
     if (!valid) {
       errors.push({
         eventName,
+        fileName: path.basename(examplePath),
         errors: validateFn.errors,
       });
     }
-  })
+  });
 }
 
 if (errors.length) {
   console.log(`🚨 Some errors were detected in examples:`);
   errors.forEach((errorSet) => {
-    console.log(`\nIn ${errorSet.eventName}`);
+    console.log(`\nIn ${errorSet.eventName}/${errorSet.fileName}`);
 
     errorSet.errors.forEach((error) => {
       console.log(`- ${error.instancePath} ${error.message}`);


### PR DESCRIPTION
`identity-check-resolved` replaces `identity-check-updated` and takes on additional responsibilities to record terminus events when any Paper ID journey finishes.

This will allow Sirius to better keep track of what is happening in an actor's ID journey, and enable specific activity that needs to happen as a result of certain events.

Includes examples and schema, and marks `identity-check-resolved` as deprecated.

For ID-500 #minor