### PR TITLE
Remove voucher details from identity check updates

### DIFF
--- a/domains/POAS/events/identity-check-updated/examples/vouch_started.json
+++ b/domains/POAS/events/identity-check-updated/examples/vouch_started.json
@@ -2,7 +2,5 @@
   "time": "2024-05-19T15:06:29Z",
   "lpaUids": ["M-14HD-3J9F-FJ9K"],
   "actorType": "donor",
-  "state": "VOUCH_STARTED",
-  "voucherName": "Glennis Edgin",
-  "voucherAddress": ["3 Chestnut Close", "Cleveland", "Dorset", "GT87 1CH"]
+  "state": "VOUCH_STARTED"
 }

--- a/domains/POAS/events/identity-check-updated/index.md
+++ b/domains/POAS/events/identity-check-updated/index.md
@@ -38,7 +38,7 @@ In all cases, the relevant progress indicator in Sirius will be updated to refle
 
 If the state is **`SUCCESS`**, the identity check details will be added to the LPA Store record. (If the LPA has not been submitted, the information is held in Sirius until it is.)
 
-If the state is **`VOUCH_STARTED`**, Sirius will send a letter to the voucher once the LPA is submitted. (If the LPA has been submitted, the letter will be sent immediately.)
+If the state is **`VOUCH_STARTED`**, Sirius will send a letter to the donor once the LPA is submitted. (If the LPA has been submitted, the letter will be sent immediately.)
 
 <NodeGraph title="Consumer / Producer Diagram" />
 

--- a/domains/POAS/events/identity-check-updated/schema.json
+++ b/domains/POAS/events/identity-check-updated/schema.json
@@ -37,18 +37,6 @@
     "reference": {
       "type": "string",
       "description": "The back-reference for a successful identity check"
-    },
-    "voucherName": {
-      "type": "string",
-      "description": "The name of the voucher that the donor nominated"
-    },
-    "voucherAddress": {
-      "type": "array",
-      "description": "The mailing address of the voucher that the donor nominated",
-      "minItems": 1,
-      "items": {
-        "type": "string"
-      }
     }
   },
   "allOf": [
@@ -61,17 +49,6 @@
       },
       "then": {
         "required": ["reference"]
-      }
-    },
-    {
-      "if": {
-        "required": ["state"],
-        "properties": {
-          "state": { "const": "VOUCH_STARTED" }
-        }
-      },
-      "then": {
-        "required": ["voucherName", "voucherAddress"]
       }
     }
   ]


### PR DESCRIPTION
Sirius will send a letter to the donor, not the voucher, so won't be sent the voucher's details

For ID-531 #patch